### PR TITLE
FEAT: TO - flexiblere Renderfunktionen

### DIFF
--- a/CGAbschlussprojekt/customopenglwidget.cpp
+++ b/CGAbschlussprojekt/customopenglwidget.cpp
@@ -200,7 +200,9 @@ void CustomOpenGLWidget::_createRenderables() {
     ctm.translate(0.f, 0.5f, 0.f);
     RenderableObject* cube = new RenderableObject(ctm,
                                                   _cubeModel,
-                                                  _defaultShaderProgram);
+                                                  SHADER_DEFAULT,
+                                                  _defaultShaderProgram,
+                                                  QVector4D(0.5f, 0.5f, 1.f, 1.f));
     _myRenderables.push_back(cube);
 
     //Sphere
@@ -217,7 +219,9 @@ void CustomOpenGLWidget::_createRenderables() {
     ctm.scale(8);
     RenderableObject* floor = new RenderableObject(ctm,
                                                    _floorModel,
+                                                   SHADER_TEXTURE,
                                                    _textureShaderProgram,
+                                                   QVector4D(1.f, 0.f, 0.f, 1.f),
                                                    "floor_texture_2_1024px.bmp");
     _myRenderables.push_back(floor);
 }

--- a/CGAbschlussprojekt/customopenglwidget.h
+++ b/CGAbschlussprojekt/customopenglwidget.h
@@ -26,7 +26,6 @@
 #include <model.h>
 #include <renderableobject.h>
 
-
 class CustomOpenGLWidget : public QOpenGLWidget,
                            protected QOpenGLFunctions {
     Q_OBJECT

--- a/CGAbschlussprojekt/default440.frag
+++ b/CGAbschlussprojekt/default440.frag
@@ -1,9 +1,9 @@
 #version 440
 
 uniform sampler2D diffuseMap;
-layout(location = 0)in vec4 texC;
+layout(location = 0)in vec4 color;
 layout(location = 0)out vec4 fragColor;
 
 void main() {
-    fragColor = vec4(0.3f, 0.3f, 1.f, 1.f); //Test
+    fragColor = color;
 }

--- a/CGAbschlussprojekt/default440.vert
+++ b/CGAbschlussprojekt/default440.vert
@@ -3,13 +3,15 @@
 layout(location = 0)uniform mat4 projectionMatrix;
 layout(location = 1)uniform mat4 viewMatrix;
 layout(location = 2)uniform mat4 modelMatrix;
+layout(location = 3)uniform vec4 colorIN;
+
 layout(location = 0)in vec4 vert;
 layout(location = 1)in vec4 norm;
-layout(location = 2)in vec4 texCoord;
-layout(location = 0)out vec4 texC;
+
+layout(location = 0)out vec4 color;
 
 void main() {
     mat4 matrix = projectionMatrix * viewMatrix * modelMatrix;
     gl_Position = matrix * vert;
-    texC = texCoord;
+    color = colorIN;
 }

--- a/CGAbschlussprojekt/renderableobject.cpp
+++ b/CGAbschlussprojekt/renderableobject.cpp
@@ -2,16 +2,23 @@
 
 RenderableObject::RenderableObject(QMatrix4x4 ctm,
                                    Model* model,
+                                   int shaderTypeFlag,
                                    QOpenGLShaderProgram* shader,
+                                   QVector4D const &baseColor,
                                    QString const &mainTextureFileName,
                                    QString const &secondTextureFileName) {
     //Parameter übertragen/eintragen
     this->_model = model;
+    _modelHasTextureCoords = (model->hasTextureCoords()) ? true : false;
+
     this->_shader = shader;
     _hasTexture = false;
     _hasSecondTexture = false;
 
     if(mainTextureFileName.length() != 0) {
+        if(!_modelHasTextureCoords) {
+            qDebug() << "#WARNING# Function: RenderableObject::RenderableObject - Model hat keine TexturCoords aber Textur wird gesetzt!";
+        }
         _setMainTexture(mainTextureFileName);
     }
 
@@ -20,6 +27,8 @@ RenderableObject::RenderableObject(QMatrix4x4 ctm,
     }
 
     _myCTM = ctm;
+    _shaderFlag = shaderTypeFlag;
+    _baseColor = baseColor;
 }
 
 void RenderableObject::_setMainTexture(QString filename) {
@@ -42,10 +51,173 @@ void RenderableObject::_setSecondTexture(QString filename) {
     qDebug() << "Textur: " << filename << " geladen";
 }
 
-void RenderableObject::render(QMatrix4x4 parentCTM,
-                              QMatrix4x4 const &viewMatrix,
-                              QMatrix4x4 const &projectionMatrix) {
+void RenderableObject::_renderWithDefaultShader(QMatrix4x4 const &parentCTM,
+                                                QMatrix4x4 const &viewMatrix,
+                                                QMatrix4x4 const &projectionMatrix) {
+    //TODO CTM Matrix Transformationen
+    QMatrix4x4 ctm;
+    ctm = parentCTM * _myCTM;
 
+    for(RenderableObject* x : _children) {
+        x->render(ctm,
+                  viewMatrix,
+                  projectionMatrix);
+    }
+
+    //VBO und IBO an den Kontext binden
+    _model->getVBOBufferPtr()->bind();
+    _model->getIBOBufferPtr()->bind();
+
+    //Matrix Locations für den Shader
+    int unifProjMatrix = 0;
+    int unifViewMatrix = 1;
+    int unifModelMatrix = 2;
+    int unifColor = 3;
+
+    //Matrix Berechnungen fertig nun shader konfigurieren
+    _shader->bind();
+
+    // Lokalisiere bzw. definiere die Schnittstelle für die Eckpunkte, Normalen und Textur
+    int attrVertices = 0;
+    int attrNorms = 1;
+
+    // Aktiviere die Verwendung der Attribute-Arrays
+    _shader->enableAttributeArray(attrVertices);
+    _shader->enableAttributeArray(attrNorms);
+
+    // Fülle die Attribute-Buffer mit den korrekten Daten
+    size_t model_stride = _model->stride(); //reduziert von 3 auf 1 Aufruf (implizit uint in int ist aktzeptabel - kein Werteverlust)
+    _shader->setAttributeBuffer(attrVertices, GL_FLOAT, _model->vertOffset(), 4, model_stride); //VertexPositionen
+    _shader->setAttributeBuffer(attrNorms, GL_FLOAT, _model->normOffset(), 4, model_stride); //VertexNormalen
+
+    //Uniforms an den Shader übergeben
+    _shader->setUniformValue(unifProjMatrix, projectionMatrix); //projektionsMatrix (const)
+    _shader->setUniformValue(unifViewMatrix, viewMatrix); //viewMatrix ("const")
+    _shader->setUniformValue(unifModelMatrix, ctm); //modelMatrix (immer abhängig vom gerade zu rendernden RenderableObject)
+    _shader->setUniformValue(unifColor, _baseColor);
+
+
+    //PolygonMode einstellen
+    glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+
+    //Element zeichnen lassen (implizit uint in int ist aktzeptabel - kein Werteverlust)
+    glDrawElements(GL_TRIANGLES, _model->iboLength(), GL_UNSIGNED_INT, 0);
+
+    //PolygonMode auf default setzen
+    glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+
+    // Deaktiviere die Verwendung der Attribute-Arrays
+    _shader->disableAttributeArray(attrVertices);
+    _shader->disableAttributeArray(attrNorms);
+
+    //Shader lösen
+    _shader->release();
+
+    //VBO und IBO vom Kontext lösen
+    _model->getVBOBufferPtr()->release();
+    _model->getIBOBufferPtr()->release();
+}
+
+void RenderableObject::_renderWithTextureShader(QMatrix4x4 const &parentCTM,
+                                                QMatrix4x4 const &viewMatrix,
+                                                QMatrix4x4 const &projectionMatrix) {
+    //TODO CTM Matrix Transformationen
+    QMatrix4x4 ctm;
+    ctm = parentCTM * _myCTM;
+
+    for(RenderableObject* x : _children) {
+        x->render(ctm,
+                  viewMatrix,
+                  projectionMatrix);
+    }
+
+    //VBO und IBO an den Kontext binden
+    _model->getVBOBufferPtr()->bind();
+    _model->getIBOBufferPtr()->bind();
+
+    //Matrix Locations für den Shader
+    int unifProjMatrix = 0;
+    int unifViewMatrix = 1;
+    int unifModelMatrix = 2;
+
+    //Matrix Berechnungen fertig nun shader konfigurieren
+    _shader->bind();
+
+    // Lokalisiere bzw. definiere die Schnittstelle für die Eckpunkte, Normalen und Textur
+    int attrVertices = 0;
+    int attrNorms = 1;
+    int attrTexCoords = 2;
+
+    // Aktiviere die Verwendung der Attribute-Arrays
+    _shader->enableAttributeArray(attrVertices);
+    _shader->enableAttributeArray(attrNorms);
+    if(_model->hasTextureCoords()) {
+        _shader->enableAttributeArray(attrTexCoords);
+    }
+
+    // Fülle die Attribute-Buffer mit den korrekten Daten
+    size_t model_stride = _model->stride(); //reduziert von 3 auf 1 Aufruf (implizit uint in int ist aktzeptabel - kein Werteverlust)
+    _shader->setAttributeBuffer(attrVertices, GL_FLOAT, _model->vertOffset(), 4, model_stride); //VertexPositionen
+    _shader->setAttributeBuffer(attrNorms, GL_FLOAT, _model->normOffset(), 4, model_stride); //VertexNormalen
+    if(_modelHasTextureCoords) {
+        _shader->setAttributeBuffer(attrTexCoords, GL_FLOAT, _model->texCoordOffset(), 4, model_stride); //TexturCoordinaten
+    }
+
+    //Uniforms an den Shader übergeben
+    _shader->setUniformValue(unifProjMatrix, projectionMatrix); //projektionsMatrix (const)
+    _shader->setUniformValue(unifViewMatrix, viewMatrix); //viewMatrix ("const")
+    _shader->setUniformValue(unifModelMatrix, ctm); //modelMatrix (immer abhängig vom gerade zu rendernden RenderableObject)
+    //_shader->setUniformValue(unifNormMatrix,  (viewMatrix * ctm).normalMatrix()); //berechnete Normalenmatrix
+
+    //Haupt-Textur (und Zweit-Textur) binden und an shader übergeben
+    _mainTexture->bind(0);
+    _shader->setUniformValue("diffuseMap", 0);
+
+    /* atm nicht implementiert im shader
+    if(_hasSecondTexture) {
+        _secondTexture->bind(1);
+        _shader->setUniformValue("bumpMap?!?", 1);
+    }
+    */
+
+    //PolygonMode einstellen
+    //glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+
+    //Element zeichnen lassen (implizit uint in int ist aktzeptabel - kein Werteverlust)
+    glDrawElements(GL_TRIANGLES, _model->iboLength(), GL_UNSIGNED_INT, 0);
+
+    //PolygonMode auf default setzen
+    //glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+
+    // Deaktiviere die Verwendung der Attribute-Arrays
+    _shader->disableAttributeArray(attrVertices);
+    _shader->disableAttributeArray(attrNorms);
+    if(_modelHasTextureCoords) {
+        _shader->disableAttributeArray(attrTexCoords);
+    }
+
+    //Shader lösen
+    _shader->release();
+
+    // Löse die Textur aus dem OpenGL-Kontext
+    if(_hasTexture) {
+        _mainTexture->release();
+    }
+    /* atm nicht implementiert im shader
+    if(_hasSecondTexture) {
+        _secondTexture->release();
+    }
+    */
+
+    //VBO und IBO vom Kontext lösen
+    _model->getVBOBufferPtr()->release();
+    _model->getIBOBufferPtr()->release();
+}
+
+void RenderableObject::_renderWithMeltShader(QMatrix4x4 const &parentCTM,
+                                             QMatrix4x4 const &viewMatrix,
+                                             QMatrix4x4 const &projectionMatrix) {
+    /*
     //TODO CTM Matrix Transformationen
     QMatrix4x4 ctm;
     ctm = parentCTM * _myCTM;
@@ -105,8 +277,14 @@ void RenderableObject::render(QMatrix4x4 parentCTM,
         _shader->setUniformValue("bumpMap?!?", 1);
     }
 
+    //PolygonMode einstellen
+    glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
+
     //Element zeichnen lassen (implizit uint in int ist aktzeptabel - kein Werteverlust)
     glDrawElements(GL_TRIANGLES, _model->iboLength(), GL_UNSIGNED_INT, 0);
+
+    //PolygonMode auf default setzen
+    glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 
     // Deaktiviere die Verwendung der Attribute-Arrays
     _shader->disableAttributeArray(attrVertices);
@@ -129,6 +307,26 @@ void RenderableObject::render(QMatrix4x4 parentCTM,
     //VBO und IBO vom Kontext lösen
     _model->getVBOBufferPtr()->release();
     _model->getIBOBufferPtr()->release();
+    */
+}
+
+void RenderableObject::render(QMatrix4x4 const &parentCTM,
+                              QMatrix4x4 const &viewMatrix,
+                              QMatrix4x4 const &projectionMatrix) {
+    switch(_shaderFlag) {
+    case SHADER_DEFAULT:
+        _renderWithDefaultShader(parentCTM, viewMatrix, projectionMatrix);
+        break;
+    case SHADER_TEXTURE:
+        _renderWithTextureShader(parentCTM, viewMatrix, projectionMatrix);
+        break;
+    case SHADER_MELT:
+        _renderWithMeltShader(parentCTM, viewMatrix, projectionMatrix);
+        break;
+    default:
+        qDebug() << "#ERROR# Function: RenderableObject:render(..) - ungültige Shader-Flag!";
+        throw new std::exception();
+    }
 }
 
 void RenderableObject::addChild(RenderableObject* child) {

--- a/CGAbschlussprojekt/renderableobject.h
+++ b/CGAbschlussprojekt/renderableobject.h
@@ -14,15 +14,24 @@
 //externe includes
 #include <model.h>
 
+//Shader-Code defines
+#define SHADER_DEFAULT 0x0001
+#define SHADER_TEXTURE 0x0002
+#define SHADER_MELT    0x0003
+
+
 class RenderableObject : public QObject {
     Q_OBJECT
 private:
     //Referenzen bilden 'Render-Konfiguration'
     //Geometrie
     Model* _model;
+    bool _modelHasTextureCoords; //für Performanz nur 1x
     //QMatrix4x4 _ctm; //später hier sinnvoll?
     //Optik
+    int _shaderFlag;
     QOpenGLShaderProgram* _shader;
+    QVector4D _baseColor;
     QOpenGLTexture* _mainTexture;
     QOpenGLTexture* _secondTexture;
     //Bool-Flags ob überhaupt Texturen vorhanden sind
@@ -36,15 +45,27 @@ private:
     //(ausgelagerte) Hilfsfunktionen - hauptsächlich zur Übersichtlichkeit
     void _setMainTexture(QString filename);
     void _setSecondTexture(QString filename);
+    //verschiedene Renderfunktionen
+    void _renderWithDefaultShader(QMatrix4x4 const &parentCTM,
+                                  QMatrix4x4 const &viewMatrix,
+                                  QMatrix4x4 const &projectionMatrix);
+    void _renderWithTextureShader(QMatrix4x4 const &parentCTM,
+                                  QMatrix4x4 const &viewMatrix,
+                                  QMatrix4x4 const &projectionMatrix);
+    void _renderWithMeltShader(QMatrix4x4 const &parentCTM,
+                               QMatrix4x4 const &viewMatrix,
+                               QMatrix4x4 const &projectionMatrix);
 public:
     //Konstruktor
     RenderableObject(QMatrix4x4 ctm,
                      Model* model,
+                     int shaderTypeFlag,
                      QOpenGLShaderProgram* shader,
+                     QVector4D const &baseColor,
                      QString const &mainTextureFileName = "",
                      QString const &secondTextureFileName = "");
-    //Allgemeine Renderfunktion FUTURE Alternative Calls mit ohne Textur etc?
-    virtual void render(QMatrix4x4 parentCTM,
+    //Allgemeine Renderfunktion
+    virtual void render(QMatrix4x4 const &parentCTM,
                         QMatrix4x4 const &viewMatrix,
                         QMatrix4x4 const &projectionMatrix);
     //Tree-Aufbau-Funktion


### PR DESCRIPTION
Dem Konstruktor muss nun eine shaderFlag mitgegeben werden,
danach wird immer die richtige Renderfunktion für dieses
RenderableObject aufgerufen.

Fixed das dazugehörige Issue.